### PR TITLE
I am attempting to fix the errors in building experienced at Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ deploy:
   provider: heroku
   strategy: api
   on:
-    all_branches: true
+    all_branches: false
   app:
     master: jas-mis-app-staging
     production: jas-mis-app-prod


### PR DESCRIPTION
The idea is to stop Travis from deploying on all branches of `master`.  The main reason why travis errors is because heroku has no container targeted for a branch called `css-fixes`.
